### PR TITLE
Change rgl.* calls to *3d calls.

### DIFF
--- a/R/picknplot.shape.r
+++ b/R/picknplot.shape.r
@@ -286,7 +286,7 @@ picknplot.shape <- function(x, ...){
       rgl.snapshot(filename = file.name)
     }
     if(ans=="n"){
-      try(rgl.close(), silent=T)
+      try(close3d(), silent=T)
     }
     continue <- readline("Do you want to pick another point (y/n)? ")
     p = p + 1

--- a/R/plotspec.r
+++ b/R/plotspec.r
@@ -114,9 +114,8 @@ plotspec <- function (spec, digitspec, fixed = NULL, fixed.pt.col = "red", fixed
   do.call(plot3d, plot3d.args)
 
   plot3d.args <- plot3d.args[c("x", "y", "z", "col", "size")]
-  plot3d.args$type = "points"
   
-  do.call(rgl.primitive, plot3d.args)
+  do.call(points3d, plot3d.args)
   
   if(!is.null(mesh)) shade3d(mesh, meshColor = "legacy", add = TRUE)
   
@@ -124,8 +123,7 @@ plotspec <- function (spec, digitspec, fixed = NULL, fixed.pt.col = "red", fixed
     p2.args <- xyz.coords(digitspec[1:fixed,])
     p2.args$size = fixed.pt.size
     p2.args$col = fixed.pt.col
-    p2.args$type <- "points"
-    do.call(rgl.primitive, p2.args)
+    do.call(points3d, p2.args)
     
     if(nrow(digitspec) > fixed) {
       p2.args$x <- digitspec[(fixed + 1):nrow(digitspec), 1]
@@ -133,7 +131,7 @@ plotspec <- function (spec, digitspec, fixed = NULL, fixed.pt.col = "red", fixed
       p2.args$z <- digitspec[(fixed + 1):nrow(digitspec), 3]
       p2.args$size <- plot3d.args$size
       p2.args$col <- plot3d.args$col
-      do.call(rgl.primitive, p2.args)
+      do.call(points3d, p2.args)
     } 
   }
 


### PR DESCRIPTION
An upcoming release of `rgl` will deprecate a large number of `rgl.*` functions, including `rgl.close` and `rgl.primitive` that are used in `geomorph`.  This PR replaces them with approximate equivalents.